### PR TITLE
Support referring to plugins and themes that are known to be compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ Uses the [PHPCompatibility PHPCS sniffs](https://github.com/wimg/PHPCompatibilit
 and interprets the WordPress-specific results. Defaults to '7.0-' for scanning
 PHP 7.0 and above.
 
+If a theme or plugin is compatible, it results with `compat=success`. If
+there's an incompatibility, it results with `compat=failure`.
+
 Speed up the scanning process by using [php-compat-cache](https://github.com/danielbachhuber/php-compat-cache), a collection of pre-scanned WordPress.org
-plugins and themes.
+plugins and themes. If a theme or plugin is known to be compatible with
+an update, it results `compat=with-update`.
 
 **OPTIONS**
 
@@ -79,9 +83,22 @@ plugins and themes.
     | twentysixteen         | theme  | success | 1.3     | cached | 23    |
     +-----------------------+--------+---------+---------+--------+-------+
 
+    # Plugin is known to be compatible with an update
+    $ WP_CLI_PHP_COMPAT_CACHE=~/php-compat-cache wp php-compat
+    +-----------------+--------+--------------+---------+--------+-------+
+    | name            | type   | compat       | version | time   | files |
+    +-----------------+--------+--------------+---------+--------+-------+
+    | wordpress       | core   | success      | 4.9.8   | cached |       |
+    | akismet         | plugin | success      | 4.0.8   | cached | 13    |
+    | woocommerce     | plugin | with-update  | 3.2.6   | cached |       |
+    | twentyfifteen   | theme  | success      | 2.0     | 0.25s  | 22    |
+    | twentyseventeen | theme  | success      | 1.7     | 0.3s   | 35    |
+    | twentysixteen   | theme  | success      | 1.5     | 0.28s  | 23    |
+    +-----------------+--------+--------------+---------+--------+-------+
+
 ## Installing
 
-Installing this package requires WP-CLI's latest stable release. Update to the latest stable release with `wp cli update`.
+Installing this package requires WP-CLI v2 or greater. Update to the latest stable release with `wp cli update`.
 
 Once you've done so, you can install this package with:
 
@@ -111,7 +128,7 @@ Once you've decided to commit the time to seeing your pull request through, [ple
 
 ## Support
 
-Github issues aren't for general support questions, but there are other venues you can try: http://wp-cli.org/#support
+Github issues aren't for general support questions, but there are other venues you can try: https://wp-cli.org/#support
 
 
 *This README.md is generated dynamically from the project's codebase using `wp scaffold package-readme` ([doc](https://github.com/wp-cli/scaffold-package-command#wp-scaffold-package-readme)). To suggest changes, please submit a pull request against the corresponding part of the codebase.*

--- a/features/php-compat.feature
+++ b/features/php-compat.feature
@@ -72,6 +72,31 @@ Feature: Check PHP compatibility
       | name            | type       | compat         | time      |
       | co-authors-plus | plugin     | success        | cached    |
 
+  Scenario: Plugin formally supports PHP 7 in a newer version
+    Given a WP install
+    And a php-compat-cache/plugins-php7-compat.txt file:
+      """
+      # Plugins and the minimum version they have formal PHP 7 compat.
+      woocommerce,3.3.0
+      """
+    And I run `wp plugin install woocommerce --version=3.2.6`
+
+    When I run `WP_CLI_PHP_COMPAT_CACHE=php-compat-cache wp php-compat --fields=name,type,compat,time`
+    Then STDOUT should be a table containing rows:
+      | name        | type       | compat         | time   |
+      | woocommerce | plugin     | with-update    | cached |
+
+    When I run `wp plugin update woocommerce`
+    Then STDOUT should contain:
+      """
+      Success:
+      """
+
+    When I run `WP_CLI_PHP_COMPAT_CACHE=php-compat-cache wp php-compat --fields=name,type,compat`
+    Then STDOUT should be a table containing rows:
+      | name        | type       | compat         |
+      | woocommerce | plugin     | success        |
+
    Scenario: Invalid php_version argument specified
      Given a WP install
 

--- a/src/PHP_Compat_Command.php
+++ b/src/PHP_Compat_Command.php
@@ -11,8 +11,12 @@ class PHP_Compat_Command {
 	 * and interprets the WordPress-specific results. Defaults to '7.0-' for scanning
 	 * PHP 7.0 and above.
 	 *
+	 * If a theme or plugin is compatible, it results with `compat=success`. If
+	 * there's an incompatibility, it results with `compat=failure`.
+	 *
 	 * Speed up the scanning process by using [php-compat-cache](https://github.com/danielbachhuber/php-compat-cache), a collection of pre-scanned WordPress.org
-	 * plugins and themes.
+	 * plugins and themes. If a theme or plugin is known to be compatible with
+	 * an update, it results `compat=with-update`.
 	 *
 	 * ## OPTIONS
 	 *
@@ -72,6 +76,19 @@ class PHP_Compat_Command {
 	 *     | twentyseventeen       | theme  | success | 1.1     | cached | 35    |
 	 *     | twentysixteen         | theme  | success | 1.3     | cached | 23    |
 	 *     +-----------------------+--------+---------+---------+--------+-------+
+	 *
+	 *     # Plugin is known to be compatible with an update
+	 *     $ WP_CLI_PHP_COMPAT_CACHE=~/php-compat-cache wp php-compat
+	 *     +-----------------+--------+--------------+---------+--------+-------+
+	 *     | name            | type   | compat       | version | time   | files |
+	 *     +-----------------+--------+--------------+---------+--------+-------+
+	 *     | wordpress       | core   | success      | 4.9.8   | cached |       |
+	 *     | akismet         | plugin | success      | 4.0.8   | cached | 13    |
+	 *     | woocommerce     | plugin | with-update  | 3.2.6   | cached |       |
+	 *     | twentyfifteen   | theme  | success      | 2.0     | 0.25s  | 22    |
+	 *     | twentyseventeen | theme  | success      | 1.7     | 0.3s   | 35    |
+	 *     | twentysixteen   | theme  | success      | 1.5     | 0.28s  | 23    |
+	 *     +-----------------+--------+--------------+---------+--------+-------+
 	 *
 	 * @when before_wp_load
 	 */

--- a/src/PHP_Compat_Command.php
+++ b/src/PHP_Compat_Command.php
@@ -207,6 +207,14 @@ class PHP_Compat_Command {
 			2 => array( 'pipe', 'w' ),
 		);
 
+		$known_upgrade_version = self::get_extension_known_upgradable( $php_version, $extension['type'], $result['name'] );
+		if ( $known_upgrade_version && version_compare( $result['version'], $known_upgrade_version, '<' ) ) {
+			$result['compat'] = 'with-update';
+			$result['time'] = 'cached';
+			$result['files'] = '';
+			return $result;
+		}
+
 		$php_compat_cache = getenv( 'WP_CLI_PHP_COMPAT_CACHE' );
 		if ( $php_compat_cache ) {
 			$cache_file = Utils\trailingslashit( realpath( $php_compat_cache ) ) . $extension['type'] . 's/' . $extension['basename'] . '/' . $extension['basename'] . '.' . $extension['version'] . '.json';
@@ -252,6 +260,48 @@ class PHP_Compat_Command {
 			$result['compat'] = 'failure';
 		}
 		return $result;
+	}
+
+	/**
+	 * Some plugins and themes are known to be compatible with upgrade.
+	 *
+	 * @param string $php_version PHP version currently being checked.
+	 * @param string $type        Type of extension: theme or plugin.
+	 * @param string $name        Name of the extension.
+	 * @return string|false       Version string where the theme or plugin supports the version checked.
+	 */
+	private static function get_extension_known_upgradable( $php_version, $type, $name ) {
+		// Our scan cache only contains '7.0-' scans right now.
+		if ( '7.0-' !== $php_version ) {
+			return false;
+		}
+		static $file_data;
+		if ( ! isset( $file_data ) ) {
+			$file_data = array();
+		}
+
+		$php_compat_cache = getenv( 'WP_CLI_PHP_COMPAT_CACHE' );
+		if ( $php_compat_cache && ! isset( $file_data[ $type ] ) ) {
+			$file = Utils\trailingslashit( realpath( $php_compat_cache ) ) . $type . 's-php7-compat.txt';
+			$file_data[ $type ] = array();
+			if ( file_exists( $file ) ) {
+				$file_contents = file_get_contents( $file );
+				$lines = explode( PHP_EOL, trim( $file_contents ) );
+				if ( ! empty( $lines ) ) {
+					foreach ( $lines as $line ) {
+						if ( empty( $line ) ) {
+							continue;
+						}
+						if ( ! empty( $line[0] ) && '#' === $line[0] ) {
+							continue;
+						}
+						list( $supported_name, $supported_version ) = array_map( 'trim', explode( ',', $line ) );
+						$file_data[ $type ][ $supported_name ] = $supported_version;
+					}
+				}
+			}
+		}
+		return isset( $file_data[ $type ][ $name ] ) ? $file_data[ $type ][ $name ] : false;
 	}
 
 	private static function get_phpcs_exec() {


### PR DESCRIPTION
If a plugin / theme is compatible at a later version, then indicate such
with `compat=with-update`

```
$ WP_CLI_PHP_COMPAT_CACHE=~/php-compat-cache wp php-compat
+-----------------+--------+--------------+---------+--------+-------+
| name            | type   | compat       | version | time   | files |
+-----------------+--------+--------------+---------+--------+-------+
| wordpress       | core   | success      | 4.9.8   | cached |       |
| akismet         | plugin | success      | 4.0.8   | cached | 13    |
| woocommerce     | plugin | with-update  | 3.2.6   | cached |       |
| twentyfifteen   | theme  | success      | 2.0     | 0.25s  | 22    |
| twentyseventeen | theme  | success      | 1.7     | 0.3s   | 35    |
| twentysixteen   | theme  | success      | 1.5     | 0.28s  | 23    |
+-----------------+--------+--------------+---------+--------+-------+
```