### PR TITLE
Define `'files' => ''` to avoid dynamic property error

### DIFF
--- a/src/PHP_Compat_Command.php
+++ b/src/PHP_Compat_Command.php
@@ -217,6 +217,7 @@ class PHP_Compat_Command {
 		$result = array(
 			'name'     => $extension['basename'],
 			'version'  => $extension['version'],
+			'files'    => '',
 		);
 		$descriptors = array(
 			0 => STDIN,


### PR DESCRIPTION
Fixes https://github.com/danielbachhuber/php-compat-command/issues/19